### PR TITLE
inputMonth: add returnNumber and returnAbbreviation parameters

### DIFF
--- a/src/pyinputplus/__init__.py
+++ b/src/pyinputplus/__init__.py
@@ -1022,10 +1022,18 @@ def inputMonth(
     blockRegexes=None,
     applyFunc=None,
     postValidateApplyFunc=None,
+    returnNumber=False,
+    returnAbbreviation=False
 ):
-    # type: (str, Any, bool, Optional[float], Optional[int], Union[None, str, bool], Union[None, Sequence[Union[Pattern, str]]], Union[None, Sequence[Union[Pattern, str, Sequence[Union[Pattern, str]]]]], Optional[Callable], Optional[Callable]) -> Any
+    # type: (str, Any, bool, Optional[float], Optional[int], Union[None, str, bool], Union[None, Sequence[Union[Pattern, str]]], Union[None, Sequence[Union[Pattern, str, Sequence[Union[Pattern, str]]]]], Optional[Callable], Optional[Callable], bool, bool) -> Any
     """Prompts the user to enter a month name.
-    Returns a string of the selected month name in titlecase.
+    Returns a string of the selected month name in titlecase (unless
+     a. ``returnNumber`` is ``True``, in which case it returns the
+       number of the month, e.g. 1 for January, 2 for February, ...,
+       12 for December
+     b. ``returnAbbreviation`` is ``True``, in which case it returns the
+       three-letter abbreviation for the month, e.g. 'Jan' for January,
+       'Feb' for February, ..., 'Dec' for December)
 
     Run ``help(pyinputplus.parameters)`` for an explanation of the common parameters.
 
@@ -1042,12 +1050,23 @@ def inputMonth(
     MARCH
     >>> response
     'March'
+    >>> response = pyip.inputMonth(returnNumber=True)
+    March
+    >>> response
+    3
+    >>> response = pyip.inputMonth(returnAbbreviation=True)
+    March
+    >>> response
+    'Mar'
     """
-
-    # TODO add returnNumber and returnAbbreviation parameters.
-
     validationFunc = lambda value: pysv.validateMonth(
-        value, blank=blank, strip=strip, allowRegexes=allowRegexes, blockRegexes=blockRegexes,
+        value,
+        blank=blank,
+        strip=strip,
+        allowRegexes=allowRegexes,
+        blockRegexes=blockRegexes,
+        returnNumber=returnNumber,
+        returnAbbreviation=returnAbbreviation,
     )
 
     return _genericInput(

--- a/tests/test_pyinputplus.py
+++ b/tests/test_pyinputplus.py
@@ -816,6 +816,11 @@ class test_main(unittest.TestCase):
 
         self._testValidationParameters(pyip.validateMonth)
 
+        for month_index_zero_indexed, month in enumerate('january', 'february', 'march', 'april', 'may', 'june', 'july', 'august', 'september', 'october', 'november', 'december'):
+            assert pyip.validateMonth(month, returnNumber=True) == month_index_zero_indexed + 1
+
+        for month in ('january', 'february', 'march', 'april', 'may', 'june', 'july', 'august', 'september', 'october', 'november', 'december'):
+            assert pyip.validateMonth(month, returnAbbreviation=True) == month[:3].title()
 
     def test_validateDayOfWeek(self):
         pyip.validateDayOfWeek('Monday') # Test that a valid value doesn't raise an exception.


### PR DESCRIPTION
This commit aims to implement
```
TODO add returnNumber and returnAbbreviation parameters
```

It aims to implement for `inputMonth` the parameters `returnNumber` and `returnAbbreviation` similarly to how `inputUSState` implements `returnStateName`. `inputUSState` passes `returnStateName` to the `validationFunc` that calls a function from library `pysimplevalidate`.

This commit changes the files in `pyinputplus`. A separate commit and pull request will change the files in `pysimplevalidate`.

`src/pyinputplus/__init__.py`
\- `inputMonth` -- add parameters, `returnNumber` and `returnAbbreviation`
-- edit type signature of function
-- edit docstring to note the return types and values when `returnNumber` and `returnAbbreviation`
-- edit doctests by adding a case for `returnNumber` and a case for `returnAbbreviation`
-- edit `validationFunc` by passing `returnNumber` and `returnAbbreviation`

`tests/test_pyinputplus.py`
\- edit `test_main.test_validateMonth`
-- add block to check output when pass `returnNumber=True`
-- add block to check output when pass `returnAbbreviation=True`